### PR TITLE
Bugfix

### DIFF
--- a/LazyLoot/LazyLoot.js
+++ b/LazyLoot/LazyLoot.js
@@ -291,7 +291,7 @@ var LazyLoot = LazyLoot || (function() {
 
             notes = (notes === "null") ? '' : notes;
 
-            let re = new RegExp('[0-9]x ' + item.name, 'gm');
+            let re = new RegExp('[0-9]+x ' + item.name, 'gm');
             if(notes.match(re)){
                 quantity += parseInt(notes.match(re)[0].split(' ')[0]);
                 notes = notes.replace(re, quantity + 'x ' + item.name);


### PR DESCRIPTION
Line 294 RegExp needs to have a '+' added after the [0-9] as the quantity += will not properly add to total quantity.
Ex: Have a user grab 11 quantity of an item and then grab another 12 right after and you will get 113 quantity instead of the proper 23. Other issues will result in NaN inserted in the quantity because of this.